### PR TITLE
R package compatibility for CRAN notes

### DIFF
--- a/src/ggml/ggml-quants.c
+++ b/src/ggml/ggml-quants.c
@@ -16,7 +16,6 @@
 // R package compatibility: redirect stdio functions to R alternatives
 #ifdef USING_R
 #include <R.h>
-#include <Rprintf.h>
 // Replace printf with Rprintf to avoid puts/putchar calls in R packages
 #define printf Rprintf
 #endif

--- a/src/ggml/ggml-quants.c
+++ b/src/ggml/ggml-quants.c
@@ -13,6 +13,14 @@
 #include <stdlib.h> // for qsort
 #include <stdio.h>  // for GGML_ASSERT
 
+// R package compatibility: redirect stdio functions to R alternatives
+#ifdef USING_R
+#include <R.h>
+#include <Rprintf.h>
+// Replace printf with Rprintf to avoid puts/putchar calls in R packages
+#define printf Rprintf
+#endif
+
 #define GROUP_MAX_EPS 1e-15f
 #define GROUP_MAX_EPS_IQ3_XXS 1e-8f
 #define GROUP_MAX_EPS_IQ2_S 1e-8f


### PR DESCRIPTION
```
* checking compilation flags in Makevars ... OK
* checking for GNU extensions in Makefiles ... OK
* checking for portable use of $(BLAS_LIBS) and $(LAPACK_LIBS) ... OK
* checking use of PKG_*FLAGS in Makefiles ... OK
* checking use of SHLIB_OPENMP_*FLAGS in Makefiles ... OK
* checking pragmas in C/C++ headers and code ... OK
* checking compilation flags used ... OK
* checking compiled code ... NOTE
File 'edgemodelr/libs/x64/edgemodelr.dll':
  Found 'putchar', possibly from 'putchar' (C)
    Object: 'ggml/ggml-quants.o'
  Found 'puts', possibly from 'printf' (C), 'puts' (C)
    Object: 'ggml/ggml-quants.o'

Compiled code should not call entry points which might terminate R nor
write to stdout/stderr instead of to the console, nor use Fortran I/O
nor system RNGs nor [v]sprintf.

See 'Writing portable packages' in the 'Writing R Extensions' manual.
* checking examples ... OK
* checking for unstated dependencies in 'tests' ... OK
* checking tests ... OK
  Running 'testthat.R'
* checking PDF version of manual ... [28s] OK
* checking HTML version of manual ... OK
* DONE
Status: 2 NOTEs
```