### PR TITLE
Remove C++17 as is it implicit (and default will be C++20 in R 4.6.0)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Suggests:
     knitr,
     rmarkdown,
     curl
-SystemRequirements: C++17, GNU make or equivalent for building
+SystemRequirements: GNU make or equivalent for building
 Note: Package includes self-contained 'llama.cpp' implementation (~56MB)
   for complete functionality without external dependencies.
 Config/testthat/edition: 3


### PR DESCRIPTION
This is just a suggestion but CRAN _really_ put the screw on packages still declaring C++11 or C++14 and now nags when we specify C++17 as it prepares for C++20 becoming the default (!!) with R 4.6.0 come April (and hence already the default in r-devel now).

I find it easier to just go with the flow.  It can create issues -- a user of RcppSimdJson on R 4.2.3 could not compile (as that outdated R version defaults to C++14 rather than C++17).  But that is their deployment issue: "old R" and "current packages" is not a great idea, and not tested at CRAN hence no guarantees.

Long story short: I recommend lifting these constraints unless they are truly required. `edgemodelr` builds fine under C++20 so no issue here as best as I can see.