### PR TITLE
Fix CRAN pre-test issues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,15 +11,6 @@ Authors@R: c(
     person("pi6am", role = "ctb", comment = "DRY sampler from Koboldcpp"),
     person("Ivan", "Yurchenko", role = "ctb", comment = "Z-algorithm implementation"),
     person("Dirk", "Eddelbuettel", role = c("ctb", "rev")))
-Author: Pawan Rama Mali [aut, cre, cph],
-  Georgi Gerganov [aut, cph] (Author of llama.cpp and GGML library),
-  The ggml authors [cph] (llama.cpp and GGML contributors),
-  Jeffrey Quesnelle [ctb, cph] (YaRN RoPE implementation),
-  Bowen Peng [ctb, cph] (YaRN RoPE implementation),
-  pi6am [ctb] (DRY sampler from Koboldcpp),
-  Ivan Yurchenko [ctb] (Z-algorithm implementation),
-  Dirk Eddelbuettel [ctb] (Connection handling fix)
-Maintainer: Pawan Rama Mali <prm@outlook.in>
 Description: Enables R users to run large language models locally using 'GGUF' model files
     and the 'llama.cpp' inference engine. Provides a complete R interface for loading models,
     generating text completions, and streaming responses in real-time. Supports local

--- a/src/ggml/ggml-backend-reg.cpp
+++ b/src/ggml/ggml-backend-reg.cpp
@@ -602,36 +602,36 @@ static fs::path get_executable_path() {
 
 static fs::path backend_filename_prefix() {
 #ifdef _WIN32
-    return fs::u8path("ggml-");
+    return fs::path("ggml-");
 #else
-    return fs::u8path("libggml-");
+    return fs::path("libggml-");
 #endif
 }
 
 static fs::path backend_filename_extension() {
 #ifdef _WIN32
-    return fs::u8path(".dll");
+    return fs::path(".dll");
 #else
-    return fs::u8path(".so");
+    return fs::path(".so");
 #endif
 }
 
 static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent, const char * user_search_path) {
     // enumerate all the files that match [lib]ggml-name-*.[so|dll] in the search paths
-    const fs::path name_path = fs::u8path(name);
-    const fs::path file_prefix = backend_filename_prefix().native() + name_path.native() + fs::u8path("-").native();
+    const fs::path name_path = fs::path(name);
+    const fs::path file_prefix = backend_filename_prefix().native() + name_path.native() + fs::path("-").native();
     const fs::path file_extension = backend_filename_extension();
 
     std::vector<fs::path> search_paths;
     if (user_search_path == nullptr) {
 #ifdef GGML_BACKEND_DIR
-        search_paths.push_back(fs::u8path(GGML_BACKEND_DIR));
+        search_paths.push_back(fs::path(GGML_BACKEND_DIR));
 #endif
         // default search paths: executable directory, current directory
         search_paths.push_back(get_executable_path());
         search_paths.push_back(fs::current_path());
     } else {
-        search_paths.push_back(fs::u8path(user_search_path));
+        search_paths.push_back(fs::path(user_search_path));
     }
 
     int best_score = 0;


### PR DESCRIPTION
## Summary
Fixes issues identified in CRAN pre-test submission:

1. **DESCRIPTION Mismatch** - Removed manual `Author` and `Maintainer` fields, letting R auto-generate them from `Authors@R` to ensure consistency

2. **Deprecated u8path Warning** - Replaced `fs::u8path()` with `fs::path()` in `ggml-backend-reg.cpp` to fix C++20 deprecation warnings on Debian

## Test Results
- R CMD check: No ERRORs, No WARNINGs
- All platforms pass on GitHub Actions