### PR TITLE
Fix CRAN example downloads and CI version warning

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -142,12 +142,17 @@ jobs:
             exit 1
           fi
 
-          if grep -q "WARNING" "$CHECK_DIR/00check.log"; then
-            echo "⚠️  WARNINGs found in CRAN checks"
+          # Check for WARNINGs but ignore "Insufficient package version" which is expected
+          # when checking the same version that's already on CRAN
+          WARNING_COUNT=$(grep -c "WARNING" "$CHECK_DIR/00check.log" || echo "0")
+          VERSION_WARNING=$(grep -c "Insufficient package version" "$CHECK_DIR/00check.log" || echo "0")
+
+          if [ "$WARNING_COUNT" -gt "$VERSION_WARNING" ]; then
+            echo "⚠️  WARNINGs found in CRAN checks (excluding version warning)"
             exit 1
           fi
 
-          echo "✓ CRAN checks passed (only NOTEs or OK)"
+          echo "✓ CRAN checks passed (only NOTEs or expected warnings)"
         shell: bash
 
       - name: Upload check results
@@ -274,8 +279,13 @@ jobs:
             exit 1
           fi
 
-          if grep -q "WARNING" "$CHECK_DIR/00check.log"; then
-            echo "⚠️  WARNINGs found in strict macOS checks"
+          # Check for WARNINGs but ignore "Insufficient package version" which is expected
+          # when checking the same version that's already on CRAN
+          WARNING_COUNT=$(grep -c "WARNING" "$CHECK_DIR/00check.log" || echo "0")
+          VERSION_WARNING=$(grep -c "Insufficient package version" "$CHECK_DIR/00check.log" || echo "0")
+
+          if [ "$WARNING_COUNT" -gt "$VERSION_WARNING" ]; then
+            echo "⚠️  WARNINGs found in strict macOS checks (excluding version warning)"
             exit 1
           fi
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: edgemodelr
 Type: Package
 Title: Local Large Language Model Inference Engine
-Version: 0.1.5
+Version: 0.1.6
 Authors@R: c(
     person("Pawan Rama", "Mali", email = "prm@outlook.in", role = c("aut", "cre", "cph")),
     person("Georgi", "Gerganov", role = c("aut", "cph"), comment = "Author of llama.cpp and GGML library"),
@@ -30,7 +30,8 @@ Suggests:
     testthat (>= 3.0.0),
     knitr,
     rmarkdown,
-    curl
+    curl,
+    shiny
 SystemRequirements: GNU make or equivalent for building
 Note: Package includes self-contained 'llama.cpp' implementation (~56MB)
   for complete functionality without external dependencies.

--- a/man/edge_chat_stream.Rd
+++ b/man/edge_chat_stream.Rd
@@ -25,15 +25,16 @@ NULL (runs interactively)
 Interactive chat session with streaming responses
 }
 \examples{
-\donttest{
+\dontrun{
+# Requires a downloaded model (not run in checks)
 setup <- edge_quick_setup("TinyLlama-1.1B")
 ctx <- setup$context
 
 if (!is.null(ctx)) {
   # Start interactive chat with streaming
-  # edge_chat_stream(ctx, 
-  #   system_prompt = "You are a helpful R programming assistant.")
-  
+  edge_chat_stream(ctx,
+    system_prompt = "You are a helpful R programming assistant.")
+
   edge_free_model(ctx)
 }
 }

--- a/man/edge_completion.Rd
+++ b/man/edge_completion.Rd
@@ -22,7 +22,8 @@ Generated text as character string
 Generate text completion using loaded model
 }
 \examples{
-\donttest{
+\dontrun{
+# Requires a downloaded model (not run in checks)
 model_path <- "model.gguf"
 if (file.exists(model_path)) {
   ctx <- edge_load_model(model_path)

--- a/man/edge_download_model.Rd
+++ b/man/edge_download_model.Rd
@@ -23,15 +23,15 @@ Path to the downloaded model file
 Download a GGUF model from Hugging Face
 }
 \examples{
-\donttest{
-# Download TinyLlama model
-#model_path <- edge_download_model(
-#  model_id = "TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF",
-#  filename = "tinyllama-1.1b-chat-v1.0.q4_k_m.gguf"
-#)
+\dontrun{
+# Download TinyLlama model (large file, not run in checks)
+model_path <- edge_download_model(
+  model_id = "TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF",
+  filename = "tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf"
+)
 
-# Use the downloaded model (example only - requires actual model)
-if (FALSE && file.exists(model_path)) {
+# Use the downloaded model
+if (file.exists(model_path)) {
   ctx <- edge_load_model(model_path)
   response <- edge_completion(ctx, "Hello, how are you?")
   edge_free_model(ctx)

--- a/man/edge_download_url.Rd
+++ b/man/edge_download_url.Rd
@@ -25,18 +25,11 @@ This function is useful for downloading models from GPT4All CDN or other direct 
 that don't require authentication.
 }
 \examples{
-\donttest{
-# Download from GPT4All CDN
+\dontrun{
+# Download from GPT4All CDN (large file, not run in checks)
 model_path <- edge_download_url(
   url = "https://gpt4all.io/models/gguf/mistral-7b-instruct-v0.1.Q4_0.gguf",
   filename = "mistral-7b.gguf"
 )
-
-# Use the downloaded model
-if (file.exists(model_path)) {
-  ctx <- edge_load_model(model_path)
-  response <- edge_completion(ctx, "Hello!")
-  edge_free_model(ctx)
-}
 }
 }

--- a/man/edge_free_model.Rd
+++ b/man/edge_free_model.Rd
@@ -14,7 +14,8 @@ NULL (invisibly)
 Free model context and release memory
 }
 \examples{
-\donttest{
+\dontrun{
+# Requires a downloaded model (not run in checks)
 model_path <- "model.gguf"
 if (file.exists(model_path)) {
   ctx <- edge_load_model(model_path)

--- a/man/edge_load_model.Rd
+++ b/man/edge_load_model.Rd
@@ -18,16 +18,16 @@ External pointer to the loaded model context
 Load a local GGUF model for inference
 }
 \examples{
-\donttest{
-# Load a TinyLlama model
+\dontrun{
+# Load a TinyLlama model (requires model file)
 model_path <- "~/models/TinyLlama-1.1B-Chat.Q4_K_M.gguf"
 if (file.exists(model_path)) {
   ctx <- edge_load_model(model_path, n_ctx = 2048)
-  
+
   # Generate completion
   result <- edge_completion(ctx, "Explain R data.frame:", n_predict = 100)
   cat(result)
-  
+
   # Free model when done
   edge_free_model(ctx)
 }

--- a/man/edge_quick_setup.Rd
+++ b/man/edge_quick_setup.Rd
@@ -18,8 +18,8 @@ List with model path and context (if llama.cpp is available)
 Quick setup for a popular model
 }
 \examples{
-\donttest{
-# Quick setup with TinyLlama
+\dontrun{
+# Quick setup with TinyLlama (downloads model, not run in checks)
 setup <- edge_quick_setup("TinyLlama-1.1B")
 ctx <- setup$context
 

--- a/man/edge_stream_completion.Rd
+++ b/man/edge_stream_completion.Rd
@@ -25,13 +25,14 @@ List with full response and generation statistics
 Stream text completion with real-time token generation
 }
 \examples{
-\donttest{
+\dontrun{
+# Requires a downloaded model (not run in checks)
 model_path <- "model.gguf"
 if (file.exists(model_path)) {
   ctx <- edge_load_model(model_path)
-  
+
   # Basic streaming with token display
-  result <- edge_stream_completion(ctx, "Hello, how are you?", 
+  result <- edge_stream_completion(ctx, "Hello, how are you?",
     callback = function(data) {
       if (!data$is_final) {
         cat(data$token)
@@ -41,7 +42,7 @@ if (file.exists(model_path)) {
       }
       return(TRUE)  # Continue generation
     })
-  
+
   edge_free_model(ctx)
 }
 }


### PR DESCRIPTION
## Summary
- Change all `\donttest{}` to `\dontrun{}` in .Rd files to prevent model downloads during CRAN checks
- Fix CI workflow to ignore "Insufficient package version" warning which is expected when checking version already on CRAN
- Bump version to 0.1.6

## Problem
CRAN checks were running `\donttest{}` examples which attempted to download large model files (~4GB). This left behind downloaded files and caused check issues.

## Solution
Changed all examples that download models from `\donttest{}` to `\dontrun{}` so they are never executed during CRAN checks.

Also fixed the CI workflow which was failing because it detected a WARNING for "Insufficient package version" - this is expected when running checks on a version that's already on CRAN and should be ignored.

## Files changed
- `DESCRIPTION` - Version bump to 0.1.6
- `man/*.Rd` - Changed `\donttest{}` to `\dontrun{}` for all download examples
- `.github/workflows/R-CMD-check.yaml` - Ignore version warning in CI

## Test plan
- [ ] CI passes without false positive warnings
- [ ] CRAN checks pass without downloading models