### PR TITLE
Fix double-accept of sampled token in grammar-constrained generation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# edgemodelr (development)
+
+## Grammar Sampler Fix
+
+* **`bindings.cpp`**: Removed a redundant manual `llama_sampler_accept()` call
+  from the three generation loops (plain completion, streaming completion,
+  grammar-constrained completion). `llama_sampler_sample()` already calls
+  `llama_sampler_accept()` internally; the double-accept was corrupting
+  grammar state on every token. Fixes `edge_grammar_completion()`,
+  `edge_extract()`, `edge_extract_batch()`, and `edge_classify()` on Windows,
+  where these previously returned only `"{"` or truncated structured output.
+
 # edgemodelr 0.4.1
 
 ## CRAN Resubmission Fixes

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -324,8 +324,7 @@ std::string edge_completion_internal(SEXP model_ptr, std::string prompt, int n_p
         continue;
       }
       
-      // Accept the token for sampling history
-      llama_sampler_accept(sampler, new_token);
+      // llama_sampler_sample already called accept — do not call it again.
 
       // Prepare next batch with the new token
       batch = llama_batch_get_one(&new_token, 1);
@@ -506,8 +505,7 @@ List edge_completion_stream_internal(SEXP model_ptr, std::string prompt, Functio
         continue;
       }
 
-      // Accept the token for sampling history
-      llama_sampler_accept(sampler, new_token);
+      // llama_sampler_sample already called accept — do not call it again.
 
       // Prepare next batch with the new token
       batch = llama_batch_get_one(&new_token, 1);
@@ -518,7 +516,7 @@ List edge_completion_stream_internal(SEXP model_ptr, std::string prompt, Functio
         break;
       }
     }
-    
+
     // Send final callback
     try {
       List final_callback_data = List::create(
@@ -619,6 +617,8 @@ std::string edge_completion_grammar_internal(SEXP model_ptr, std::string prompt,
     result.reserve(n_predict * 8);
 
     for (int i = 0; i < n_predict; ++i) {
+      // llama_sampler_sample applies constraints, selects a token, AND calls
+      // llama_sampler_accept internally — do NOT call accept again afterward.
       llama_token new_token = llama_sampler_sample(sampler, edge_ctx->ctx, -1);
 
       if (llama_vocab_is_eog(vocab, new_token)) break;
@@ -633,13 +633,6 @@ std::string edge_completion_grammar_internal(SEXP model_ptr, std::string prompt,
         result.append(piece.data(), n_chars);
       }
 
-      try {
-        llama_sampler_accept(sampler, new_token);
-      } catch (const std::exception &) {
-        // Grammar fully satisfied by this token — no further tokens are allowed.
-        // The token's text is already in `result`; stop generating cleanly.
-        break;
-      }
       batch = llama_batch_get_one(&new_token, 1);
       if (llama_decode(edge_ctx->ctx, batch)) break;
     }


### PR DESCRIPTION
## Summary
- `llama_sampler_sample()` already calls `llama_sampler_accept()` internally. The three generation loops in `src/bindings.cpp` were calling `llama_sampler_accept()` a second time per token, advancing the grammar state twice and leaving the stack inconsistent.
- Symptoms: `edge_grammar_completion()`, `edge_extract()`, `edge_extract_batch()`, and `edge_classify()` returned only `"{"` or otherwise truncated structured output on Windows builds.
- Fix: removed the explicit `llama_sampler_accept()` call from each of the three loops and dropped the `try { ... } catch` that suppressed the secondary `"Unexpected empty grammar stack"` — that exception was a symptom of the double-accept, not a real grammar-exhaustion event.

## Verification
- `edge_grammar_completion()` and `edge_extract()` now return complete JSON for TinyLlama-1.1B, Qwen3-1.7B, and Qwen3-4B Q4_K_M on Windows.
- `edge_classify()` returns enum values matching the requested category set on the same models.
- Round-trip benchmark (`examples/pharma_benchmark.R` in the companion PR) shows Qwen3-1.7B scoring 7/7 fields correct on `edge_verify_narrative()` after this fix.

## Test plan
- [ ] `R CMD check` is clean on Linux and Windows.
- [ ] `Rscript examples/test_pharma_ae_qwen.R` runs to completion with non-truncated JSON output.
- [ ] No regression in non-grammar `edge_completion()` paths.